### PR TITLE
Session Controller에서 Dto를 VO를 전환하는 과정에서의 예외처리

### DIFF
--- a/src/main/java/com/ahastudio/makaoGift/controllers/SessionController.java
+++ b/src/main/java/com/ahastudio/makaoGift/controllers/SessionController.java
@@ -36,21 +36,24 @@ public class SessionController {
     public LoginResultDto login(
             @Valid @RequestBody LoginRequestDto loginRequestDto
     ) {
-        MemberName memberName = new MemberName(loginRequestDto.getMemberName());
-        Password password = new Password(loginRequestDto.getPassword());
+        try {
+            MemberName memberName = new MemberName(loginRequestDto.getMemberName());
+            Password password = new Password(loginRequestDto.getPassword());
 
-        Member member = loginService.login(memberName, password);
+            Member member = loginService.login(memberName, password);
 
-        Name name = member.name();
-        Money amount = member.amount();
+            String accessToken = jwtUtil.encode(memberName.value());
+            Name name = member.name();
+            Money amount = member.amount();
 
-        String accessToken = jwtUtil.encode(memberName.value());
-
-        return new LoginResultDto(
-                accessToken,
-                name.value(),
-                amount.amount()
-        );
+            return new LoginResultDto(
+                    accessToken,
+                    name.value(),
+                    amount.amount()
+            );
+        } catch (Exception exception) {
+            throw new LoginFailed();
+        }
     }
 
     @ExceptionHandler(LoginFailed.class)


### PR DESCRIPTION
Session Controller에서 받게되는 Dto가 VO로 전환되는 과정에서 유효성 검증을 통과하지 못하면 생성예러를 던졌는데 Session Controller는 로그인과 관련된 내용만 예외처리하고 있어서 500에러를 반환하고 있었음. Session Controller에서 MemberName과 Passowrd 생성 시 유효성 검증을 통과하지 못하면 LogInFailed를 던지게 수정